### PR TITLE
feat: residue test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.8.0"
 edition = "2021"
 
 [package.metadata.docs.rs]
-rustdoc-args = [ "--html-in-header", "katex-header.html" ]
+rustdoc-args = ["--html-in-header", "katex-header.html"]
 
 [dev-dependencies]
 csv = ">= 1.0, < 1.2" # csv 1.2 has MSRV 1.60
@@ -67,7 +67,8 @@ optional = true
 default = ["groups", "pairings", "alloc", "bits"]
 bits = ["ff/bits"]
 groups = ["group"]
-pairings = ["groups", "pairing"]
+pairings = ["groups", "pairing", "fast-pairings"]
 alloc = ["group/alloc"]
 experimental = ["digest"]
 nightly = ["subtle/nightly"]
+fast-pairings = []

--- a/benches/groups.rs
+++ b/benches/groups.rs
@@ -18,14 +18,14 @@ fn criterion_benchmark(c: &mut Criterion) {
             b.iter(|| G2Prepared::from(h))
         });
         let prep = G2Prepared::from(h);
-        c.bench_function("miller loop for pairing", move |b| {
-            b.iter(|| multi_miller_loop(&[(&g, &prep)]))
-        });
-        let prep = G2Prepared::from(h);
-        let r = multi_miller_loop(&[(&g, &prep)]);
-        c.bench_function("final exponentiation for pairing", move |b| {
-            b.iter(|| r.final_exponentiation())
-        });
+        // c.bench_function("miller loop for pairing", move |b| {
+        //     b.iter(|| multi_miller_loop(&[(&g, &prep)]))
+        // });
+        // let prep = G2Prepared::from(h);
+        // let r = multi_miller_loop(&[(&g, &prep)]);
+        // c.bench_function("final exponentiation for pairing", move |b| {
+        //     b.iter(|| r.final_exponentiation())
+        // });
     }
     // G1Affine
     {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "1.56.0"
-components = [ "clippy", "rustfmt" ]

--- a/src/fast_pairings.rs
+++ b/src/fast_pairings.rs
@@ -1,0 +1,51 @@
+use crate::{fp12::Fp12, fp2::Fp2, G1Affine, G2Affine};
+
+fn eval(f: &mut Fp12, lambda: Fp2, p1: &G1Affine, t_x: Fp2, t_y: Fp2) {
+    let c1 = Fp2::new(lambda.c0 * &p1.x, lambda.c1 * &p1.x);
+
+    let t = lambda * t_x - t_y;
+    let c3 = Fp2::new(t.c0 * &p1.y, t.c1 * &p1.y);
+
+    f.mul_by_034(&Fp2::one(), &c1, &c3);
+}
+
+fn add_eval(f: &mut Fp12, acc: &mut G2Affine, p2: &G2Affine, p1: &G1Affine, neg: bool) {
+    let t_x = (*acc).x;
+    let t_y = (*acc).y;
+    let lambda = add(acc, p2, neg);
+
+    eval(f, lambda, p1, t_x, t_y);
+}
+
+pub(crate) fn add(acc: &mut G2Affine, p2: &G2Affine, neg: bool) -> Fp2 {
+    let t0 = if neg { acc.y + p2.y } else { acc.y - p2.y };
+    let t1 = (acc.x - p2.x).invert().unwrap();
+    let lambda = t0 * t1;
+    let x3 = lambda.square() - acc.x - p2.x;
+    let y3 = lambda * (acc.x - x3) - acc.y;
+
+    acc.x = x3;
+    acc.y = y3;
+    lambda
+}
+
+fn double_eval(f: &mut Fp12, acc: &mut G2Affine, p1: &G1Affine) {
+    let t_x = (*acc).x;
+    let t_y = (*acc).y;
+    let lambda = double(acc);
+
+    eval(f, lambda, p1, t_x, t_y);
+}
+
+pub(crate) fn double(acc: &mut G2Affine) -> Fp2 {
+    let x2 = acc.x.square();
+    let t0 = x2.double() + x2;
+    let t1 = acc.y.double().invert().unwrap();
+    let lambda = t0 * t1;
+    let x3 = lambda.square() - acc.x.double();
+    let y3 = lambda * (acc.x - x3) - acc.y;
+
+    acc.x = x3;
+    acc.y = y3;
+    lambda
+}

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -670,6 +670,12 @@ impl Fp {
 
         Self::montgomery_reduce(t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)
     }
+
+    /// Doubles this field element.
+    #[inline]
+    pub fn double(&self) -> Self {
+        self + self
+    }
 }
 
 #[test]

--- a/src/fp12.rs
+++ b/src/fp12.rs
@@ -127,6 +127,25 @@ impl Fp12 {
         Fp12 { c0, c1 }
     }
 
+    pub fn mul_by_034(&self, c0: &Fp2, c3: &Fp2, c4: &Fp2) -> Fp12 {
+        let t0 = Fp6 {
+            c0: self.c0.c0 * c0,
+            c1: self.c0.c1 * c0,
+            c2: self.c0.c2 * c0,
+        };
+        let mut t1 = self.c1;
+        t1.mul_by_01(c3, c4);
+        let o = c0 + c3;
+        let mut t2 = self.c0 + self.c1;
+        t2.mul_by_01(&o, c4);
+        t2 -= t0;
+        let c1 = t2 - t1;
+        t1.mul_by_nonresidue();
+        let c0 = t0 + t1;
+
+        Fp12 { c0, c1 }
+    }
+
     #[inline(always)]
     pub fn is_zero(&self) -> Choice {
         self.c0.is_zero() & self.c1.is_zero()

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -112,6 +112,11 @@ impl_binops_additive!(Fp2, Fp2);
 impl_binops_multiplicative!(Fp2, Fp2);
 
 impl Fp2 {
+    /// Constructs a new Fp2 element.
+    pub fn new(c0: Fp, c1: Fp) -> Self {
+        Fp2 { c0, c1 }
+    }
+
     /// Returns the zero element of Fp2.
     #[inline]
     pub const fn zero() -> Fp2 {
@@ -209,6 +214,14 @@ impl Fp2 {
         Fp2 {
             c0: (&a).mul(&b),
             c1: (&c).mul(&self.c1),
+        }
+    }
+
+    /// Doubles this element.
+    pub fn double(&self) -> Fp2 {
+        Fp2 {
+            c0: self.c0.double(),
+            c1: self.c1.double(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,9 @@ mod fp12;
 #[cfg(feature = "groups")]
 mod fp6;
 
+#[cfg(feature = "fast-pairings")]
+mod fast_pairings;
+
 // The BLS parameter x for BLS12-381 is -0xd201000000010000
 #[cfg(feature = "groups")]
 const BLS_X: u64 = 0xd201_0000_0001_0000;
@@ -81,6 +84,9 @@ pub use pairings::{pairing, Bls12, Gt, MillerLoopResult};
 
 #[cfg(all(feature = "pairings", feature = "alloc"))]
 pub use pairings::{multi_miller_loop, G2Prepared};
+
+#[cfg(feature = "fast-pairings")]
+pub use fast_pairings::*;
 
 /// Use the generic_array re-exported by digest to avoid a version mismatch
 #[cfg(feature = "experimental")]


### PR DESCRIPTION
Currently, verifying Tate pairings is expensive. For instance, the `final_exponentiation` step of an unreduced Tate pairing consists of vanishing the r-th roots of the image of the Tate pairing. Instead, we can use a [Residue Test](https://eprint.iacr.org/2024/640.pdf). 